### PR TITLE
fix: link

### DIFF
--- a/content/en/posts/prompt-engineering/index.md
+++ b/content/en/posts/prompt-engineering/index.md
@@ -480,4 +480,4 @@ From structuring prompts to managing temperature, few-shot learning, and even av
 
 ## Acknowledgement
 
-A lot of the content of this article is based on [Anthropic's Prompt Engineering Course](https://github.com/anthropics/courses/tree/master/prompt_engineering_interactive_tutorial) with the visualizations from [Emmanuel Ogebe](emmanuelogebe.hashnode.dev).
+A lot of the content of this article is based on [Anthropic's Prompt Engineering Course](https://github.com/anthropics/courses/tree/master/prompt_engineering_interactive_tutorial) with the visualizations from [Emmanuel Ogebe](https://emmanuelogebe.hashnode.dev).


### PR DESCRIPTION
I happened to read [Prompt Engineering Guide](https://blog.gandhidevansh.com/posts/prompt-engineering/) (great article by the way) and encountered a small bug/typo regarding a link (screenshot below). This link returns a 404.

![image](https://github.com/user-attachments/assets/387c3f32-29d3-419f-a7a0-7db76fd0db79)

This PR fixes that.